### PR TITLE
[OCM][Test Suite][CI] Disable ScienceMesh on Nextcloud 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 bin/
 ocm
-.reva/
+./reva/
 core
 temp
 server

--- a/dev/ocm-test-suite.sh
+++ b/dev/ocm-test-suite.sh
@@ -161,11 +161,11 @@ function sciencemeshInsertIntoDB() {
 rm -rf "${ENV_ROOT}/temp" && mkdir --parents "${ENV_ROOT}/temp"
 
 # copy init files.
-cp -fr  "${ENV_ROOT}/docker/scripts/reva"                           "${ENV_ROOT}/temp/"
-cp -fr  "${ENV_ROOT}/docker/configs/revad"                          "${ENV_ROOT}/temp/"
-cp -f   "${ENV_ROOT}/docker/scripts/ocmstub/index.js"               "${ENV_ROOT}/temp/index.js"
-cp -f   "${ENV_ROOT}/docker/scripts/init-owncloud-sm-ocm.sh"        "${ENV_ROOT}/temp/owncloud.sh"
-cp -f   "${ENV_ROOT}/docker/scripts/init-nextcloud-sciencemesh.sh"  "${ENV_ROOT}/temp/nextcloud.sh"
+cp -fr  "${ENV_ROOT}/docker/scripts/reva"                               "${ENV_ROOT}/temp/"
+cp -fr  "${ENV_ROOT}/docker/configs/revad"                              "${ENV_ROOT}/temp/"
+cp -f   "${ENV_ROOT}/docker/scripts/ocmstub/index.js"                   "${ENV_ROOT}/temp/index.js"
+cp -f   "${ENV_ROOT}/docker/scripts/init-owncloud-sm-ocm.sh"            "${ENV_ROOT}/temp/owncloud.sh"
+cp -f   "${ENV_ROOT}/docker/scripts/init-nextcloud-ocm-test-suite.sh"   "${ENV_ROOT}/temp/nextcloud.sh"
 
 # make sure network exists.
 docker network inspect testnet >/dev/null 2>&1 || docker network create testnet >/dev/null 2>&1

--- a/docker/scripts/init-nextcloud-ocm-test-suite.sh
+++ b/docker/scripts/init-nextcloud-ocm-test-suite.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# @michielbdejong halt on error in docker init scripts
+set -e
+
+php console.php maintenance:install --admin-user "${USER}" --admin-pass "${PASS}" --database "mysql"            \
+                                    --database-name "efss" --database-user "root" --database-host "${DBHOST}"   \
+                                    --database-pass "eilohtho9oTahsuongeeTh7reedahPo1Ohwi3aek"
+php console.php app:disable firstrunwizard
+
+# change/add lines in config.php
+sed -i "3 i\  'allow_local_remote_servers' => true,"        /var/www/html/config/config.php
+sed -i "8 i\  1 => 'nc1.docker',"                           /var/www/html/config/config.php
+sed -i "9 i\  2 => 'nc2.docker',"                           /var/www/html/config/config.php
+sed -i "10 i\ 3 => 'nextcloud1.docker',"                    /var/www/html/config/config.php
+sed -i "11 i\ 4 => 'nextcloud2.docker',"                    /var/www/html/config/config.php
+
+# php console.php app:enable sciencemesh


### PR DESCRIPTION
The Nextcloud version is locked to v27, right now the eScienceMesh app only allows for Nextcloud >= v28, so to resolve this conflict I have to temporarily disable the ScienceMesh app for Nextcloud.